### PR TITLE
chore: atoms/common.ts에 있던 ModalType을 types/common/modal.ts로 이동 (#12)

### DIFF
--- a/src/atoms/common.ts
+++ b/src/atoms/common.ts
@@ -1,19 +1,13 @@
 import { atom } from "recoil";
 
-import type { Toast } from "types";
-
-interface ModalState {
-  isOpen: boolean;
-  title: string;
-  content: React.ReactNode;
-}
+import { type Modal, type Toast } from "types";
 
 export const toastState = atom<Toast[]>({
   key: "toastState",
   default: [],
 });
 
-export const modalState = atom<ModalState>({
+export const modalState = atom<Modal>({
   key: "modalState",
   default: {
     isOpen: false,

--- a/src/types/common/index.ts
+++ b/src/types/common/index.ts
@@ -1,1 +1,2 @@
 export * from "./toast";
+export * from "./modal";

--- a/src/types/common/modal.ts
+++ b/src/types/common/modal.ts
@@ -1,0 +1,5 @@
+export interface Modal {
+  isOpen: boolean;
+  title: string;
+  content: React.ReactNode;
+}


### PR DESCRIPTION
## 💛 ISSUE 번호

- #12

<br/>

## 💙 작업 내용

- atoms/common.ts에 있던 ModalType을 types/common/modal.ts로 이동
<br/>

## 💜 참고 사항

- 공유되어야하는 사항이 있다면 여기에 작성해주세요
