### PR TITLE
feat: 카카오 로그인 서버로 인가코드 보내고 정보 받아오기로 수정 (#55)

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,10 @@
+import axios from "axios";
+import { API_URL } from "config";
+import { Login } from "types";
+
+export const getKakaoInfo = async (code: string) => {
+  const { data } = await axios.get<Login>(
+    `${API_URL}/auth/KAKAO/callback?code=${code}`
+  );
+  return data;
+};

--- a/src/components/socialLogin/kakao/KakaoLogout.tsx
+++ b/src/components/socialLogin/kakao/KakaoLogout.tsx
@@ -28,7 +28,7 @@ const KakaoLogout = ({ className }: KakaoLogoutProps) => {
   const handleKaKaoLogout = () => {
     axios
       .post(
-        "https://kapi.kakao.com/v1/user/unlink",
+        "https://kapi.kakao.com/v1/user/logout",
         {},
         {
           headers: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,8 @@
+// KAKAO_LOGIN
 export const KAKAO_CLIENT_ID = import.meta.env.VITE_APP_KAKAO_REST_API_KEY;
 export const KAKAO_REDIRECT_URI = import.meta.env.VITE_APP_KAKAO_REDIRECT_URI;
 export const KAKAO_BASE_URL = "https://kauth.kakao.com/oauth/token";
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+
+// API_URL
+export const API_URL = import.meta.env.VITE_APP_API_SERVER_URL;

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,5 +1,4 @@
-import axios from "axios";
-import { KAKAO_BASE_URL, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URI } from "config";
+import { getKakaoInfo } from "apis/user";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -9,36 +8,21 @@ const Auth = () => {
   useEffect(() => {
     const params = new URL(document.location.toString()).searchParams;
     const code = params.get("code");
-    const GRANT_TYPE = "authorization_code";
-    const data = {
-      grant_type: GRANT_TYPE,
-      client_id: KAKAO_CLIENT_ID,
-      redirect_uri: KAKAO_REDIRECT_URI,
-      code: code,
-    };
+    if (code) {
+      getKakaoInfo(code)
+        .then((res) => {
+          sessionStorage.setItem("id", JSON.stringify(res.id));
+          sessionStorage.setItem("email", JSON.stringify(res.email));
 
-    axios
-      .post(KAKAO_BASE_URL, data, {
-        headers: {
-          "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-        },
-      })
-      .then((res) => {
-        console.log("kakao login response", res.data);
-        if (res) {
-          sessionStorage.setItem(
-            "accessToken",
-            JSON.stringify(res.data.access_token)
-          );
-          sessionStorage.setItem(
-            "refreshToken",
-            JSON.stringify(res.data.refresh_token)
-          );
           navigate("/signup");
-        }
-      });
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
   }, []);
 
+  // TODO: Spinner 추가?
   return <div>login</div>;
 };
 

--- a/src/types/domain/index.ts
+++ b/src/types/domain/index.ts
@@ -1,1 +1,2 @@
 export * from "./signup";
+export * from "./login";

--- a/src/types/domain/login/index.ts
+++ b/src/types/domain/login/index.ts
@@ -1,0 +1,1 @@
+export * from "./login";

--- a/src/types/domain/login/login.ts
+++ b/src/types/domain/login/login.ts
@@ -1,0 +1,4 @@
+export interface Login {
+  email: string;
+  id: number;
+}


### PR DESCRIPTION
## 💛 ISSUE 번호

- #55

<br/>

## 💙 작업 내용

- 카카오 로그인 서버로 인가코드 보내고 정보 받아오기로 수정

<br/>

## 💜 참고 사항

- .env 추가내용 있습니다.
- axios 따로 사용하시는 법 있으시면 회원가입 api 연동때 올려주시면 보고 수정해놓겠습니다.
