### PR TITLE
feat: 둘러보기 로그인으로 이동 처리 + 둘러보기 프로필 이미지 블러처리 (#119)

### DIFF
--- a/src/components/layout/footer/Footer.tsx
+++ b/src/components/layout/footer/Footer.tsx
@@ -2,13 +2,23 @@ import { Button } from "components/buttons";
 import * as S from "./Footer.styled";
 import { HomeIcon, MyInfoIcon, MyMeetingIcon, SearchGrayIcon } from "assets";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { userIdSelector } from "atoms";
+import { useToast } from "hooks";
 
 const Footer = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { addToast } = useToast();
+  const userId = useRecoilValue(userIdSelector);
 
   const handleClickFooter = (path: string) => {
-    navigate(path);
+    if (!userId && (path === "/myMeeting" || path === "/myInfo")) {
+      addToast({ content: "로그인이 필요한 서비스 입니다." });
+      navigate("/");
+    } else {
+      navigate(path);
+    }
   };
 
   const footerArr = [

--- a/src/components/router/Router.tsx
+++ b/src/components/router/Router.tsx
@@ -3,7 +3,6 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import { Layout } from "components";
 import * as P from "pages";
-import AuthRoute from "./AuthRoute";
 
 interface RouterProps {
   children?: React.ReactNode; //TODO: Modal, Toast 컴포넌트 추가 이후 필수값으로 변경 필요
@@ -19,16 +18,13 @@ const Router = ({ children }: RouterProps) => {
           <Route index element={<P.Login />} />
           <Route path="/signup" element={<P.Signup />} />
           <Route path="/glint/auth/kakao/callback" element={<P.Auth />} />
-          // TODO: 둘러보기 미적용
-          <Route element={<AuthRoute />}>
-            <Route path="/main" element={<P.Main />} />
-            <Route path="/search" element={<P.Search />} />
-            <Route path="/myInfo" element={<P.MyInfo />} />
-            <Route path="/myProfile" element={<P.MyProfile />} />
-            <Route path="/meeting/:meetingId" element={<P.Meeting />} />
-            <Route path="/createRoom" element={<P.CreateRoom />} />
-            <Route path="/myMeeting" element={<P.MyMeeting />} />
-          </Route>
+          <Route path="/main" element={<P.Main />} />
+          <Route path="/search" element={<P.Search />} />
+          <Route path="/myInfo" element={<P.MyInfo />} />
+          <Route path="/myProfile" element={<P.MyProfile />} />
+          <Route path="/meeting/:meetingId" element={<P.Meeting />} />
+          <Route path="/createRoom" element={<P.CreateRoom />} />
+          <Route path="/myMeeting" element={<P.MyMeeting />} />
           <Route path="/loading" element={<P.Loading />} />
           <Route path="/404" element={<P.Error404 />} />
           <Route path="/*" element={<P.Error404 />} />

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -13,6 +13,8 @@ import { useGetMainNewMeetings } from "services";
 import { useEffect, useState } from "react";
 import { meetingListItem } from "types";
 import { useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import { userIdSelector } from "atoms";
 
 const Main = () => {
   const navigate = useNavigate();
@@ -25,6 +27,7 @@ const Main = () => {
   const { data } = useGetMainNewMeetings(lastMeetingId, limit);
 
   const { addToast } = useToast();
+  const userId = useRecoilValue(userIdSelector);
 
   useEffect(() => {
     if (data?.meetings) {
@@ -41,6 +44,15 @@ const Main = () => {
   const handleClickKeyword = (keyword: string) => {
     if (keyword) {
       navigate("/search", { state: keyword });
+    }
+  };
+
+  const handleAddIcon = () => {
+    if (userId) {
+      navigate("/createRoom");
+    } else {
+      addToast({ content: "로그인이 필요한 서비스 입니다." });
+      navigate("/");
     }
   };
 
@@ -85,11 +97,7 @@ const Main = () => {
             <MoreIcon />
           </S.More>
         )}
-      <Button
-        variant="icon"
-        css={S.addIcon}
-        onClick={() => navigate("/createRoom")}
-      >
+      <Button variant="icon" css={S.addIcon} onClick={handleAddIcon}>
         <AddIcon />
       </Button>
     </S.Content>

--- a/src/pages/meeting/containers/home/Home.tsx
+++ b/src/pages/meeting/containers/home/Home.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { Badge, Button } from "components";
 import { useToast } from "hooks";
@@ -11,6 +11,7 @@ import * as S from "./Home.styled";
 const Home = () => {
   const { meetingId } = useParams();
   const userId = sessionStorage.getItem("id")!;
+  const navigate = useNavigate();
 
   const { data } = useGetMeeting(meetingId!);
   const { mutate: mutatePostAttendMeetingRoom } = usePostAttendMeetingRoom();
@@ -28,16 +29,21 @@ const Home = () => {
   };
 
   const handleAttendClick = () => {
-    const req = { meetingId: meetingId!, userId: userId };
+    if (userId) {
+      const req = { meetingId: meetingId!, userId: userId };
 
-    mutatePostAttendMeetingRoom(req, {
-      onSuccess: () => {
-        addToast({ content: "참가신청 완료! 방장의 승인을 기다려주세요." });
-      },
-      onError: () => {
-        addToast({ content: "참가조건에 맞지 않는 미팅이에요." });
-      },
-    });
+      mutatePostAttendMeetingRoom(req, {
+        onSuccess: () => {
+          addToast({ content: "참가신청 완료! 방장의 승인을 기다려주세요." });
+        },
+        onError: () => {
+          addToast({ content: "참가조건에 맞지 않는 미팅이에요." });
+        },
+      });
+    } else {
+      addToast({ content: "로그인이 필요한 서비스 입니다." });
+      navigate("/");
+    }
   };
 
   return (

--- a/src/pages/meeting/containers/home/containers/profile/Profile.styled.ts
+++ b/src/pages/meeting/containers/home/containers/profile/Profile.styled.ts
@@ -31,15 +31,35 @@ export const Profile = styled.div`
   `}
 `;
 
-export const Img = styled.img`
+export const ImgContainer = styled.div<{ isBlur: boolean }>`
   position: absolute;
   top: 0;
-  display: flex;
   width: 100%;
   height: 100px;
   border-radius: 12px 12px 0 0;
   overflow: hidden;
+  ${({ isBlur }) =>
+    isBlur &&
+    css`
+      &::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        backdrop-filter: blur(10px);
+        z-index: 1;
+      }
+    `}
+`;
+
+export const Img = styled.img`
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+  position: relative;
+  z-index: 0;
 `;
 
 export const ProfileMainInfo = styled.div`

--- a/src/pages/meeting/containers/home/containers/profile/Profile.tsx
+++ b/src/pages/meeting/containers/home/containers/profile/Profile.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import * as S from "./Profile.styled";
 import { GetMeetingResponse } from "types";
 import { CircleStartIcon, InfoIcon, MeetingWaitingIcon } from "assets";
+import { useRecoilValue } from "recoil";
+import { userIdSelector } from "atoms";
 
 interface ProfileProps {
   leaderId?: number;
@@ -11,13 +13,25 @@ interface ProfileProps {
 }
 
 const Profile = ({ leaderId, peopleCapacity, users }: ProfileProps) => {
+  const [isBlur, setIsBlur] = useState(false);
+
+  const userId = useRecoilValue(userIdSelector);
+
+  useEffect(() => {
+    if (!userId) {
+      setIsBlur(true);
+    }
+  }, [userId]);
+
   if (!users || !peopleCapacity) return null;
 
   return (
     <S.ProfileWrapper>
       {users.map((user) => (
         <S.Profile key={user.id}>
-          <S.Img src={user.profileImage} alt={user.nickname} />
+          <S.ImgContainer isBlur={isBlur}>
+            <S.Img src={user.profileImage} alt={user.nickname} />
+          </S.ImgContainer>
           <S.InfoWrapper>
             <S.ProfileMainInfo>
               {leaderId === user.id && <CircleStartIcon />}


### PR DESCRIPTION
## 💛 ISSUE 번호

- #119

<br/>

## 💙 작업 내용

- 둘러보기 (내미팅, 내정보, 방만들기, 채팅참가 => 로그인화면)
- 채팅방에서 사진 블러처리

<br/>

## 💜 참고 사항

- 미팅 방에서 참가자 프로필 클릭 시에 미로그인 이면 로그인화면 이동은 안되어있습니다.
