### PR TITLE
Feat/#123 회원가입여부 수정

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,20 +1,10 @@
-import {
-  getKakaoInfoResponse,
-  getUserInfoResponse,
-  getUserResponse,
-} from "types";
+import { getKakaoInfoResponse, getUserInfoResponse } from "types";
 import { ax } from "./axios";
 
 export const getKakaoInfoAPI = async (code: string) => {
   const { data } = await ax.get<getKakaoInfoResponse>(
     `/auth/KAKAO/callback?code=${code}`
   );
-  return data;
-};
-
-export const getUserAPI = async (userId: string) => {
-  const { data } = await ax.get<getUserResponse>(`/users/${userId}`);
-
   return data;
 };
 

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,21 +1,18 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useGetKakaoInfo, useGetUser } from "services/user";
+import { useGetKakaoInfo } from "services/user";
 import * as P from "pages";
 
 const Auth = () => {
   const navigate = useNavigate();
   const params = new URL(document.location.toString()).searchParams;
   const code = params.get("code");
-  const [sessionId, setSessionId] = useState("");
-  const { data: kakaoData, error: kakaoError } = useGetKakaoInfo(code || "");
-  const { data: user, error: userError } = useGetUser(sessionId || "");
+  const { data: kakaoData, error: kakaoError } = useGetKakaoInfo(code!);
 
   useEffect(() => {
     if (kakaoData) {
       sessionStorage.setItem("id", JSON.stringify(kakaoData.id));
       sessionStorage.setItem("email", JSON.stringify(kakaoData.email));
-      setSessionId(kakaoData.id.toString());
     }
 
     if (kakaoError) {
@@ -24,28 +21,15 @@ const Auth = () => {
     }
   }, [kakaoData, kakaoError]);
 
-  // storage 이벤트 리스너를 등록하여 sessionId를 업데이트
   useEffect(() => {
-    const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === "id") {
-        setSessionId(event.newValue || "");
+    if (kakaoData) {
+      if (kakaoData.isCompleteDetail) {
+        navigate("/main");
+      } else if (!kakaoData.isCompleteDetail) {
+        navigate("/signup");
       }
-    };
-
-    window.addEventListener("storage", handleStorageChange);
-    return () => {
-      window.removeEventListener("storage", handleStorageChange);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (user?.role) {
-      navigate("/main");
     }
-    if (userError) {
-      navigate("/signup");
-    }
-  }, [sessionId, user, userError]);
+  }, [kakaoData]);
 
   return <P.Loading />;
 };

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useGetKakaoInfo } from "services/user";
 import * as P from "pages";

--- a/src/pages/auth/Auth.tsx
+++ b/src/pages/auth/Auth.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useGetKakaoInfo } from "services/user";
 import * as P from "pages";
+import { useGetKakaoInfo } from "services";
 
 const Auth = () => {
   const navigate = useNavigate();

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -2,28 +2,15 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   deleteUserAPI,
   getKakaoInfoAPI,
-  getUserAPI,
   getUserInfoAPI,
   putLogoutAPI,
 } from "apis";
-import {
-  getKakaoInfoResponse,
-  getUserInfoResponse,
-  getUserResponse,
-} from "types";
+import { getKakaoInfoResponse, getUserInfoResponse } from "types";
 
 export const useGetKakaoInfo = (code: string) => {
   return useQuery<getKakaoInfoResponse>({
     queryKey: ["kakaoInfo", code],
     queryFn: () => getKakaoInfoAPI(code),
-  });
-};
-
-export const useGetUser = (userId: string) => {
-  return useQuery<getUserResponse>({
-    queryKey: ["user", userId],
-    queryFn: () => getUserAPI(userId),
-    enabled: !!userId,
   });
 };
 

--- a/src/types/domain/login/login.ts
+++ b/src/types/domain/login/login.ts
@@ -1,4 +1,5 @@
 export interface getKakaoInfoResponse {
   email: string;
   id: number;
+  isCompleteDetail: boolean;
 }

--- a/src/types/domain/user/user.ts
+++ b/src/types/domain/user/user.ts
@@ -1,10 +1,3 @@
-export interface getUserResponse {
-  id: number;
-  email: string;
-  role: "OAUTH_USER"; // TODO: role 추가 가능성 있음
-  provider: string;
-}
-
 export interface getUserInfoResponse {
   userId: number;
   userDetail: userDetailType;


### PR DESCRIPTION
## 💛 ISSUE 번호

- #123

<br/>

## 💙 작업 내용

- 기존 카카오 로그인 callback함수 내 res의 isCompleteDetail(boolean)으로 회원가입 여부 판단 후 페이지 이동
- 회원가입 여부 판단 위해 썼던 안쓰는 api, 코드들 삭제 

<br/>

## 💜 참고 사항

- 공유되어야하는 사항이 있다면 여기에 작성해주세요
